### PR TITLE
Add new h5bp settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,13 @@ MAINTAINER Kyle Mathews "mathews.kyle@gmail.com"
 
 RUN rm /etc/nginx/nginx.conf /etc/nginx/mime.types
 COPY nginx.conf /etc/nginx/nginx.conf
+COPY basic.conf /etc/nginx/basic.conf
 COPY mime.types /etc/nginx/mime.types
 RUN mkdir /etc/nginx/ssl
 COPY default /etc/nginx/sites-enabled/default
 COPY default-ssl /etc/nginx/sites-available/default-ssl
+COPY directive-only /etc/nginx/directive-only
+COPY location /etc/nginx/location
 
 # expose both the HTTP (80) and HTTPS (443) ports
 EXPOSE 80 443

--- a/basic.conf
+++ b/basic.conf
@@ -1,0 +1,6 @@
+# Basic h5bp rules
+
+include /etc/nginx/directive-only/x-ua-compatible.conf;
+include /etc/nginx/location/expires.conf;
+include /etc/nginx/location/cross-domain-fonts.conf;
+include /etc/nginx/location/protect-system-files.conf;

--- a/default
+++ b/default
@@ -1,23 +1,24 @@
 server {
-  root /var/www;
-  index index.html index.htm;
+    root /var/www;
+    index index.html index.htm;
 
-  # Make site accessible from http://localhost/
-  server_name localhost;
+    # Make site accessible from http://localhost/
+    server_name localhost;
 
-  # Add 1 day expires header for static assets
-  location ~* \.(js|css|png|jpg|jpeg|gif|ico)$ {
-    expires 1d;
-  }
+    # Add 1 day expires header for static assets
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico)$ {
+        expires 1d;
+    }
 
-  location / {
-    # First attempt to serve request as file, then
-    # as directory, then fall back to redirecting to index.html
-    try_files $uri $uri/ @root;
-  }
+    location / {
+        # First attempt to serve request as file, then
+        # as directory, then fall back to redirecting to index.html
+        try_files $uri $uri/ @root;
+    }
 
-  # If nginx can't find a file, fallback to the homepage.
-  location @root {
-    rewrite .* / redirect;
-  }
+    # If nginx can't find a file, fallback to the homepage.
+    location @root {
+        rewrite .* / redirect;
+    }
+
 }

--- a/default
+++ b/default
@@ -21,4 +21,5 @@ server {
         rewrite .* / redirect;
     }
 
+    include /etc/nginx/basic.conf;
 }

--- a/default-ssl
+++ b/default-ssl
@@ -1,10 +1,10 @@
 server {
-        listen 443;
+    listen 443;
 
-        root /var/www;
-        index index.html index.htm;
+    root /var/www;
+    index index.html index.htm;
 
-        ssl on;
-        ssl_certificate /etc/nginx/ssl/server.crt;
-        ssl_certificate_key /etc/nginx/ssl/server.key;
+    ssl on;
+    ssl_certificate /etc/nginx/ssl/server.crt;
+    ssl_certificate_key /etc/nginx/ssl/server.key;
 }

--- a/directive-only/cache-file-descriptors.conf
+++ b/directive-only/cache-file-descriptors.conf
@@ -1,0 +1,19 @@
+# This tells Nginx to cache open file handles, "not found" errors, metadata about files and their permissions, etc.
+#
+# The upside of this is that Nginx can immediately begin sending data when a popular file is requested,
+# and will also know to immediately send a 404 if a file is missing on disk, and so on.
+#
+# However, it also means that the server won't react immediately to changes on disk, which may be undesirable.
+#
+# In the below configuration, inactive files are released from the cache after 20 seconds, whereas
+# active (recently requested) files are re-validated every 30 seconds.
+#
+# Descriptors will not be cached unless they are used at least 2 times within 20 seconds (the inactive time).
+#
+# A maximum of the 1000 most recently used file descriptors can be cached at any time.
+#
+# Production servers with stable file collections will definitely want to enable the cache.
+open_file_cache          max=1000 inactive=20s;
+open_file_cache_valid    30s;
+open_file_cache_min_uses 2;
+open_file_cache_errors   on;

--- a/directive-only/cross-domain-insecure.conf
+++ b/directive-only/cross-domain-insecure.conf
@@ -1,0 +1,14 @@
+# Cross domain AJAX requests
+
+# http://www.w3.org/TR/cors/#access-control-allow-origin-response-header
+
+# **Security Warning**
+# Do not use this without understanding the consequences.
+# This will permit access from any other website.
+#
+add_header "Access-Control-Allow-Origin" "*";
+
+# Instead of using this file, consider using a specific rule such as:
+#
+# Allow access based on [sub]domain:
+#    add_header "Access-Control-Allow-Origin" "subdomain.example.com";

--- a/directive-only/extra-security.conf
+++ b/directive-only/extra-security.conf
@@ -1,0 +1,17 @@
+# The X-Frame-Options header indicates whether a browser should be allowed
+# to render a page within a frame or iframe.
+add_header X-Frame-Options SAMEORIGIN;
+
+# MIME type sniffing security protection
+#	There are very few edge cases where you wouldn't want this enabled.
+add_header X-Content-Type-Options nosniff;
+
+# The X-XSS-Protection header is used by Internet Explorer version 8+
+# The header instructs IE to enable its inbuilt anti-cross-site scripting filter.
+add_header X-XSS-Protection "1; mode=block";
+
+# with Content Security Policy (CSP) enabled (and a browser that supports it (http://caniuse.com/#feat=contentsecuritypolicy),
+# you can tell the browser that it can only download content from the domains you explicitly allow
+# CSP can be quite difficult to configure, and cause real issues if you get it wrong
+# There is website that helps you generate a policy here http://cspisawesome.com/
+# add_header Content-Security-Policy "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' https://www.google-analytics.com;";

--- a/directive-only/no-transform.conf
+++ b/directive-only/no-transform.conf
@@ -1,0 +1,11 @@
+# Prevent mobile network providers from modifying your site
+#
+# (!) If you are using `ngx_pagespeed`, please note that setting
+# the `Cache-Control: no-transform` response header will prevent
+# `PageSpeed` from rewriting `HTML` files, and, if
+# `pagespeed DisableRewriteOnNoTransform off` is not used, also
+# from rewriting other resources.
+#
+# https://developers.google.com/speed/pagespeed/module/configuration#notransform
+
+add_header "Cache-Control" "no-transform";

--- a/directive-only/spdy.conf
+++ b/directive-only/spdy.conf
@@ -1,0 +1,11 @@
+# Nginx's spdy module is compiled by default from 1.6
+# SPDY only works on HTTPS connections
+
+# Inform browser of SPDY availability
+add_header Alternate-Protocol  443:npn-spdy/3;
+
+# Adjust connection keepalive for SPDY clients:
+spdy_keepalive_timeout 300s; # up from 180 secs default
+
+# enable SPDY header compression
+spdy_headers_comp 6;

--- a/directive-only/ssl-stapling.conf
+++ b/directive-only/ssl-stapling.conf
@@ -1,0 +1,9 @@
+# OCSP stapling...
+ssl_stapling on;
+ssl_stapling_verify on;
+
+#trusted cert must be made up of your intermediate certificate followed by root certificate
+#ssl_trusted_certificate /path/to/ca.crt;
+
+resolver 8.8.8.8 8.8.4.4 216.146.35.35 216.146.36.36 valid=60s;
+resolver_timeout 2s;

--- a/directive-only/ssl.conf
+++ b/directive-only/ssl.conf
@@ -1,0 +1,44 @@
+# Protect against the BEAST and POODLE attacks by not using SSLv3 at all. If you need to support older browsers (IE6) you may need to add
+# SSLv3 to the list of protocols below.
+ssl_protocols              TLSv1 TLSv1.1 TLSv1.2;
+
+# Ciphers set to best allow protection from Beast, while providing forwarding secrecy, as defined by Mozilla (Intermediate Set) - https://wiki.mozilla.org/Security/Server_Side_TLS#Nginx
+ssl_ciphers                ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:ECDHE-RSA-DES-CBC3-SHA:ECDHE-ECDSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA;
+ssl_prefer_server_ciphers  on;
+
+# Optimize SSL by caching session parameters for 10 minutes. This cuts down on the number of expensive SSL handshakes.
+# The handshake is the most CPU-intensive operation, and by default it is re-negotiated on every new/parallel connection.
+# By enabling a cache (of type "shared between all Nginx workers"), we tell the client to re-use the already negotiated state.
+# Further optimization can be achieved by raising keepalive_timeout, but that shouldn't be done unless you serve primarily HTTPS.
+ssl_session_cache    shared:SSL:10m; # a 1mb cache can hold about 4000 sessions, so we can hold 40000 sessions
+ssl_session_timeout  24h;
+
+# SSL buffer size was added in 1.5.9
+#ssl_buffer_size      1400; # 1400 bytes to fit in one MTU
+
+# Session tickets appeared in version 1.5.9
+#
+# nginx does not auto-rotate session ticket keys: only a HUP / restart will do so and
+# when a restart is performed the previous key is lost, which resets all previous
+# sessions. The fix for this is to setup a manual rotation mechanism:
+# http://trac.nginx.org/nginx/changeset/1356a3b9692441e163b4e78be4e9f5a46c7479e9/nginx
+#
+# Note that you'll have to define and rotate the keys securely by yourself. In absence
+# of such infrastructure, consider turning off session tickets:
+#ssl_session_tickets off;
+
+# Use a higher keepalive timeout to reduce the need for repeated handshakes
+keepalive_timeout 300s; # up from 75 secs default
+
+# HSTS (HTTP Strict Transport Security)
+# This header tells browsers to cache the certificate for a year and to connect exclusively via HTTPS.
+#add_header Strict-Transport-Security "max-age=31536000;";
+# This version tells browsers to treat all subdomains the same as this site and to load exclusively over HTTPS
+#add_header Strict-Transport-Security "max-age=31536000; includeSubdomains;";
+
+# This default SSL certificate will be served whenever the client lacks support for SNI (Server Name Indication).
+# Make it a symlink to the most important certificate you have, so that users of IE 8 and below on WinXP can see your main site without SSL errors.
+#ssl_certificate      /etc/nginx/default_ssl.crt;
+#ssl_certificate_key  /etc/nginx/default_ssl.key;
+
+# Consider using OCSP Stapling as shown in ssl-stapling.conf

--- a/directive-only/x-ua-compatible.conf
+++ b/directive-only/x-ua-compatible.conf
@@ -1,0 +1,2 @@
+# Force the latest IE version
+add_header "X-UA-Compatible" "IE=Edge";

--- a/location/cache-busting.conf
+++ b/location/cache-busting.conf
@@ -1,0 +1,10 @@
+# Built-in filename-based cache busting
+
+# https://github.com/h5bp/html5-boilerplate/blob/5370479476dceae7cc3ea105946536d6bc0ee468/.htaccess#L403
+# This will route all requests for /css/style.20120716.css to /css/style.css
+# Read also this: github.com/h5bp/html5-boilerplate/wiki/cachebusting
+# This is not included by default, because it'd be better if you use the build
+# script to manage the file names.
+location ~* (.+)\.(?:\d+)\.(js|css|png|jpg|jpeg|gif)$ {
+  try_files $uri $1.$2;
+}

--- a/location/cross-domain-fonts.conf
+++ b/location/cross-domain-fonts.conf
@@ -1,0 +1,13 @@
+# Cross domain webfont access
+location ~* \.(?:ttf|ttc|otf|eot|woff|woff2)$ {
+  include /etc/nginx/directive-only/cross-domain-insecure.conf;
+
+  # Also, set cache rules for webfonts.
+  #
+  # See http://wiki.nginx.org/HttpCoreModule#location
+  # And https://github.com/h5bp/server-configs/issues/85
+  # And https://github.com/h5bp/server-configs/issues/86
+  expires 1M;
+  access_log off;
+  add_header Cache-Control "public";
+}

--- a/location/expires.conf
+++ b/location/expires.conf
@@ -1,0 +1,43 @@
+# Expire rules for static content
+
+# No default expire rule. This config mirrors that of apache as outlined in the
+# html5-boilerplate .htaccess file. However, nginx applies rules by location,
+# the apache rules are defined by type. A consequence of this difference is that
+# if you use no file extension in the url and serve html, with apache you get an
+# expire time of 0s, with nginx you'd get an expire header of one month in the
+# future (if the default expire rule is 1 month). Therefore, do not use a
+# default expire rule with nginx unless your site is completely static
+
+# cache.appcache, your document html and data
+location ~* \.(?:manifest|appcache|html?|xml|json)$ {
+  expires -1;
+  access_log /var/log/nginx/static.log;
+}
+
+# Feed
+location ~* \.(?:rss|atom)$ {
+  expires 1h;
+  add_header Cache-Control "public";
+}
+
+# Media: images, icons, video, audio, HTC
+location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc)$ {
+  expires 1M;
+  access_log off;
+  add_header Cache-Control "public";
+}
+
+# CSS and Javascript
+location ~* \.(?:css|js)$ {
+  expires 1y;
+  access_log off;
+  add_header Cache-Control "public";
+}
+
+# WebFonts
+# If you are NOT using cross-domain-fonts.conf, uncomment the following directive
+# location ~* \.(?:ttf|ttc|otf|eot|woff|woff2)$ {
+#  expires 1M;
+#  access_log off;
+#  add_header Cache-Control "public";
+# }

--- a/location/protect-system-files.conf
+++ b/location/protect-system-files.conf
@@ -1,0 +1,13 @@
+# Prevent clients from accessing hidden files (starting with a dot)
+# This is particularly important if you store .htpasswd files in the site hierarchy
+# Access to `/.well-known/` is allowed.
+# https://www.mnot.net/blog/2010/04/07/well-known
+# https://tools.ietf.org/html/rfc5785
+location ~* /\.(?!well-known\/) {
+  deny all;
+}
+
+# Prevent clients from accessing to backup/config/source files
+location ~* (?:\.(?:bak|conf|dist|fla|in[ci]|log|psd|sh|sql|sw[op])|~)$ {
+  deny all;
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -30,6 +30,10 @@ events {
   use epoll;
 }
 
+# Log errors and warnings to this file
+# This is only used when you don't override it on a server{} level
+error_log  /var/log/nginx/error.log warn;
+
 pid        /var/run/nginx.pid;
 
 http {


### PR DESCRIPTION
Configured a basic setup based on what h5bp usually do, then users of the docker image can just replace basic.conf with their own.

@KyleAMathews Might need to update the README

Closing #9 